### PR TITLE
Enhancement (close #18) Hide warning if registration via invite

### DIFF
--- a/src/GDGUkraine/templates/register.html
+++ b/src/GDGUkraine/templates/register.html
@@ -148,7 +148,7 @@
 
     <div class="wrapper" ng-app="gdgorgua">
         <div id="main" role="main" ng-controller="contactForm">
-            {% if event.max_regs and event.max_regs - event.participants | count < 5 %}
+            {% if not invite and (event.max_regs and event.max_regs - event.participants | count < 5) %}
             <span style="background: red; color: white; text-align: center; font-weight: bolder; width: 575px; display: block; border-radius: 8px; padding: 10px; margin: 10px;">
                 Attention! The event registration is closing soon!
             </span>


### PR DESCRIPTION
If user registers via invite code there is no need to show him warning _"Attention, registration is closing soon"_ (see corresponding issue)

This pull request closes #18 and hides warning if invite code is present.

**N.B.** I think this is the best way to hide warning, but I could miss another conditions when it should not be shown, hence I've created this PR.

Review request @webknjaz 