### PR TITLE
Travis integration. Closes #54

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install:
     - pip install -U -r requirements/dev.txt
     - pip install -U mysql-connector-python || pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip\#md5\=3df394d89300db95163f17c843ef49df
-    - pip install -U -e .
+    - pip install -e .
 
 # Environmental variables
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     global:
         - NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml
         - >
-            BLUEBERRYPY_CONFIG="{ 'sqlalchemy_engine': { 'url': 'sqlite://' } }"
+            BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }'
 
 # Run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ install:
 
 # Environmental variables
 env:
-    # These will be set always
+    # Will be set always
     global:
-        - >
-            BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }'
+        - BLUEBERRYPY_CONFIG='{}'
 
     # At least one build per one of the following variable
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 # Scripts to install dependencies
 install:
-    - pip install -U -r requirements/dev.txt --no-use-wheel
+    - pip install -U -r requirements/test.txt --no-use-wheel
     - pip install -U mysql-connector-python --no-use-wheel || pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip\#md5\=3df394d89300db95163f17c843ef49df --no-use-wheel
     - pip install -e . --no-use-wheel
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+version:
+    - 3.4
+    - 3.5
+
+# Scripts to install dependencies
+install:
+    - pip install -U -r requirements/dev.txt
+    - pip install -U mysql-connector-python || pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip\#md5\=3df394d89300db95163f17c843ef49df
+    - pip install -U -e .
+
+# Environmental variables
+env:
+    # These will be set always
+    global:
+        - NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml
+
+# Run tests
+script:
+    - pre-commit run --all-files
+    - nosetests -w src/tests --tests=test_utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
 
 # Scripts to install dependencies
 install:
-    - pip install -U -r requirements/dev.txt
-    - pip install -U mysql-connector-python || pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip\#md5\=3df394d89300db95163f17c843ef49df
-    - pip install -e .
+    - pip install -U -r requirements/dev.txt --no-use-wheel
+    - pip install -U mysql-connector-python --no-use-wheel || pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip\#md5\=3df394d89300db95163f17c843ef49df --no-use-wheel
+    - pip install -e . --no-use-wheel
 
 # Environmental variables
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-version:
+python:
     - 3.4
     - 3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     # These will be set always
     global:
         - NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml
-        - BLUEBEBERRYPY_CONFIG={ "sqlalchemy_engine": { "url": "sqlite://" } }
+        - BLUEBERRYPY_CONFIG="{ 'sqlalchemy_engine': { 'url': 'sqlite://' } }"
 
 # Run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ env:
 
 # Run tests
 script:
-    - tox
+    - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     # These will be set always
     global:
         - NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml
+        - BLUEBEBERRYPY_CONFIG={ "sqlalchemy_engine": { "url": "sqlite://" } }
 
 # Run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ env:
     # These will be set always
     global:
         - NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml
-        - BLUEBERRYPY_CONFIG="{ 'sqlalchemy_engine': { 'url': 'sqlite://' } }"
+        - >
+            BLUEBERRYPY_CONFIG="{ 'sqlalchemy_engine': { 'url': 'sqlite://' } }"
 
 # Run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,22 @@
 language: python
-python:
-    - 3.4
-    - 3.5
+python: 3.5
 
 # Scripts to install dependencies
 install:
-    - pip install -U -r requirements/test.txt --no-use-wheel
-    - pip install -U mysql-connector-python --no-use-wheel || pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip\#md5\=3df394d89300db95163f17c843ef49df --no-use-wheel
-    - pip install -e . --no-use-wheel
+    - pip install tox
 
 # Environmental variables
 env:
     # These will be set always
     global:
-        - NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml
         - >
             BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }'
 
+    # At least one build per one of the following variable
+    matrix:
+        - TOX_ENV=py34-codestyle,py34-nosetests
+        - TOX_ENV=py35-codestyle,py35-nosetests
+
 # Run tests
 script:
-    - pre-commit run --all-files
-    - nosetests -w src/tests --tests=test_utils
+    - tox

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ We have `bin/update_gdg` script for this
 
 You can use [`tox`](https://tox.readthedocs.org) to run tests as well. Unfortunately, due to some bug in tox itself some special steps are required.
 
-    [gdg.org.ua]$ BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }' tox
+    [gdg.org.ua]$ BLUEBERRYPY_CONFIG='{}' tox
 
 You can also run only specific set of tests. To do that, add `-e toxenv[,toxenv]` to tox comand. For example, to run tests only for python3.5, use the following command:
 
-    [gdg.org.ua]$ BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }' tox -e py35-codestyle,py35-nosetests
+    [gdg.org.ua]$ BLUEBERRYPY_CONFIG='{}' tox -e py35-codestyle,py35-nosetests
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ We have `bin/update_gdg` script for this
     [gdg.org.ua]$ pip install -U -r requirements/test.txt
     [gdg.org.ua]$ NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml nosetests -w src/tests --tests=test_utils
 
+You can use [`tox`](https://tox.readthedocs.org) to run tests as well. Unfortunately, due to some bug in tox itself some special steps are required.
+
+    [gdg.org.ua]$ BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }' tox
+
+You can also run only specific set of tests. To do that, add `-e toxenv[,toxenv]` to tox comand. For example, to run tests only for python3.5, use the following command:
+
+    [gdg.org.ua]$ BLUEBERRYPY_CONFIG='{ "sqlalchemy_engine": { "url": "sqlite://" } }' tox -e py35-codestyle,py35-nosetests
+
 ## Troubleshooting
 
 ### Converting packages to python3

--- a/config/test/app.yml
+++ b/config/test/app.yml
@@ -2,10 +2,13 @@ project_metadata:
   package: GDGUkraine
 
 global:
+  environment: test_suite
   engine.url_for.on: true
-  cherrypy.engine.logging.on: false
   engine.sqlalchemy.on: true
   base_app_url: http://testhost:12345
+  alembic:
+    script_location: src/db
+    sqlalchemy.url: &db_url sqlite://gdg.db
 
 controllers:
   '':
@@ -57,7 +60,7 @@ controllers:
       tools.sessions.on: true
 
 sqlalchemy_engine:
-  url: "sqlite://"
+  url: *db_url
   pool_recycle: 60
 
 jinja2:

--- a/config/test/app.yml
+++ b/config/test/app.yml
@@ -57,7 +57,7 @@ controllers:
       tools.sessions.on: true
 
 sqlalchemy_engine:
-  url: <connection uri here>
+  url: "sqlite://"
   pool_recycle: 60
 
 jinja2:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 pre-commit==0.7.6
 -r common.txt
 hg+https://hg@bitbucket.org/webknjaz/blueberrypy-wk#egg=blueberrypy[speedups,dev]
+tox==2.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,3 @@
 pre-commit==0.7.6
 -r common.txt
 hg+https://hg@bitbucket.org/webknjaz/blueberrypy-wk#egg=blueberrypy[speedups,dev]
-tox==2.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 redis==2.10.5
+tox==2.3.1
 -r dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ basepython=
     py35: python3.5
 
 commands=
-    python -c "import os; print(os.getenv('BLUEBERRYPY_CONFIG'))"
     codestyle: pre-commit run --all-files
     nosetests: nosetests -w src/tests --tests=test_utils
 
@@ -26,5 +25,6 @@ envdir=
     py35: {toxworkdir}/py35
 
 setenv=
-    BLUEBERRYPY_CONFIG=\{"'sqlalchemy_engine': "\{" 'url': 'sqlite://' "\}" "\}
+# Pass an environmental variable due to bug in tox
+    BLUEBERRYPY_CONFIG={env:BLUEBERRYPY_CONFIG}
     NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[flake8]
+exclude = .git,__pycache,*/migrations/*,*/db/versions/*
+
+
+[tox]
+envlist = py{34,35}-{codestyle,nosetests}
+ignore_errors=True
+
+
+[testenv]
+basepython=
+    py34: python3.4
+    py35: python3.5
+
+commands=
+    python -c "import os; print(os.getenv('BLUEBERRYPY_CONFIG'))"
+    codestyle: pre-commit run --all-files
+    nosetests: nosetests -w src/tests --tests=test_utils
+
+deps=
+    -rrequirements/test.txt
+    http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
+
+envdir=
+    py34: {toxworkdir}/py34
+    py35: {toxworkdir}/py35
+
+setenv=
+    BLUEBERRYPY_CONFIG=\{"'sqlalchemy_engine': "\{" 'url': 'sqlite://' "\}" "\}
+    NOSE_TESTCONFIG_AUTOLOAD_YAML=config/test/app.yml

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ basepython=
     py35: python3.5
 
 commands=
+    python --version
     codestyle: pre-commit run --all-files
     nosetests: nosetests -w src/tests --tests=test_utils
 


### PR DESCRIPTION
Travis integration closes #54
Add CI integration.
Use tox for running tests within different environments

Due to bug in tox there is a workaround with passing envvar to tests command.

-------------
Review request: @webknjaz 