### PR TITLE
[Fix] Fix error when creating participant

### DIFF
--- a/src/GDGUkraine/rest_controller.py
+++ b/src/GDGUkraine/rest_controller.py
@@ -124,7 +124,7 @@ class Participants(APIBase):
 
         # Get request data
         u = req.json.get('user', {})
-        fields = req.json.get('fields')
+        fields = req.json.get('fields', {})
 
         # Validate form data
         regform = RegistrationForm(hidden=None, formdata=InputDict(u))


### PR DESCRIPTION
STR:
- event without additional fields
- try to register with correct form

Expected:
- participation registered

Actual:
- it does not

Reason: getting fields with None as default fallback caused errors when
None was passed to the form constructor