### PR TITLE
Add ishell command to vagga

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,7 @@
 -r test-env.txt
 -r common.txt
 git+git://github.com/open-craft-guild/blueberrypy#egg=blueberrypy[speedups,dev]
+
+# For debugging purposes
+ipython
+ipdb

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -101,6 +101,12 @@ commands:
     container: app
     run: [ blueberrypy ]
 
+
+  ishell: !Command
+    description: Run iPython REPL within project directory
+    container: app
+    run: [ipython]
+
   mysql: !Command
     description: Run RDBMS shell
     container: mysql


### PR DESCRIPTION
vagga ishell is a convenient way to run the IPython interpreter inside a
container. Alongside with ipython itself ipdb module has been added as a
dev requirement so you can use IPython when debugging the application.