### PR TITLE
Prevent XSS by user input in card

### DIFF
--- a/src/GDGUkraine/templates/card.html
+++ b/src/GDGUkraine/templates/card.html
@@ -109,13 +109,13 @@
         {% for field_name in ['name', 'surname', 'nickname', 'phone', 'gplus', 'www', 'experience_level', 'experienc_desc', 'interests', 'events_visited', 'english_knowledge', 't_shirt_size', 'gender', 'additional_info'] %}
             <tr>
                 <td><b>{{ field_name }}</b></td>
-                <td>{{ registration.user[field_name] }}</td>
+                <td>{{ registration.user[field_name] | e }}</td>
             </tr>
         {% endfor %}
         {% for field_name in registration.fields %}
             <tr>
                 <td><b>{{ field_name }}</b></td>
-                <td>{{ registration.fields[field_name] }}</td>
+                <td>{{ registration.fields[field_name] | e }}</td>
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
If user is an asshole he might want to include some XSS into his
registration data. And when admin opens application info for this user,
admin will encounter xss attack.
This commit prevents basic xss attacks by escaping user-input data in
the card.html template.